### PR TITLE
docs(readme): add Windows to supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center"><strong>Capture. End of day. Share.</strong></p>
 
 <p align="center">
-  macOS 13+ &nbsp;·&nbsp; Linux &nbsp;·&nbsp; Free while in early access &nbsp;·&nbsp; Works with Claude, ChatGPT, Gemini (Copilot coming soon)
+  macOS 13+ &nbsp;·&nbsp; Windows &nbsp;·&nbsp; Linux &nbsp;·&nbsp; Free while in early access &nbsp;·&nbsp; Works with Claude, ChatGPT, Gemini (Copilot coming soon)
 </p>
 
 <p align="center">


### PR DESCRIPTION
Windows ships as part of the beta — the latest release includes `Sig-Setup-<version>.exe` alongside the macOS dmg/zip and Linux AppImage, but the README platform line listed only macOS and Linux.

Changes `macOS 13+ · Linux` → `macOS 13+ · Windows · Linux`.

Providers line left as-is: `copilot` is `comingSoon: true` in the app (`src/shared/vendor-families.ts`), so "Copilot coming soon" is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
